### PR TITLE
修复linux下make时无open命令的问题

### DIFF
--- a/makefile
+++ b/makefile
@@ -20,10 +20,12 @@ makecls: $(MAIN).dtx
 ifeq ($(OS), Windows_NT)
     PLATFORM = Windows
 else
-    ifeq ($(shell uname), Darwin)
+    UNAME := $(shell uname)
+    ifeq ($(UNAME), Darwin)
         PLATFORM = MacOS
-    else
-        PLATFORM = Unix-Like
+    endif
+    ifeq ($(UNAME), Linux)
+        PLATFORM = Linux
     endif
 endif
 
@@ -32,10 +34,18 @@ ifeq ($(PLATFORM), Windows)
     OPEN = cmd /c start
     CLOSE = cmd /c taskkill /im Acrobat.exe /t /f
 else
-    RM = rm -rf
-    OPEN = open
-    PID = $$(ps -ef | grep AdobeAcrobat | grep -v grep | awk '{print $$2}')
-    CLOSE = kill -9 $(PID)
+    ifeq ($(PLATFORM), MacOS)
+        RM = rm -rf
+        OPEN = open
+        PID = $$(ps -ef | grep AdobeAcrobat | grep -v grep | awk '{print $$2}')
+        CLOSE = kill -9 $(PID)
+    endif
+    ifeq ($(PLATFORM), Linux)	
+        RM = rm -rf
+        OPEN = xdg-open
+        PID = $$(ps -ef | grep evince | grep -v grep | awk '{print $$2}')
+        CLOSE = kill -9 $(PID)
+    endif
 endif
 
 texsample: $(MAIN)-sample.tex


### PR DESCRIPTION
主要是修改了makefile

# 修改了平台判断

unix-like常见的应该也就Mac和Linux了吧（

```makefile
    UNAME := $(shell uname)
    ifeq ($(UNAME), Darwin)
        PLATFORM = MacOS
    endif
    ifeq ($(UNAME), Linux)
        PLATFORM = Linux
    endif
```

# linux中使用xdg-open打开编译好的pdf

参考[linux.die.net](https://linux.die.net/man/1/xdg-open)的文档，`xdg-open`用于桌面上使用默认打开方式打开文件/url。与macos上的open用法一致。

# linux下假设使用evince打开pdf

close查找pid的时候修改成了evince。evince是ubuntu的默认文档编辑器，考虑到应该也很少人用其他发行版。


