### PR TITLE
增加VSCODE工作区支持、devcontainer配置、fonts文件夹自动映射

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+FROM qmcgaw/latexdevcontainer:latest-full
+RUN apt install -y texlive-full make

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,70 @@
+# Development container
+
+Development container that can be used with VSCode.
+
+It works on Linux, Windows and OSX.
+
+## Requirements
+
+- [VS code](https://code.visualstudio.com/download) installed
+- [VS code remote containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) installed
+- [Docker](https://www.docker.com/products/docker-desktop) installed and running
+- [Docker Compose](https://docs.docker.com/compose/install/) installed
+
+## Setup
+
+1. Create the following files on your host if you don't have them:
+
+    ```sh
+    touch ~/.gitconfig ~/.zsh_history
+    ```
+
+    Note that the development container will create the empty directories `~/.docker` and `~/.ssh` if you don't have them.
+
+1. **For Docker on OSX or Windows without WSL**: ensure your home directory `~` is accessible by Docker.
+1. **For Docker on Windows without WSL:** if you want to use SSH keys, bind mount your host `~/.ssh` to `/tmp/.ssh` instead of `~/.ssh` by changing the `volumes` section in the [docker-compose.yml](docker-compose.yml).
+1. Open the command palette in Visual Studio Code (CTRL+SHIFT+P).
+1. Select `Remote-Containers: Open Folder in Container...` and choose the project directory.
+
+## Customization
+
+### Customize the image
+
+You can make changes to the [Dockerfile](Dockerfile) and then rebuild the image. For example, your Dockerfile could be:
+
+```Dockerfile
+FROM qmcgaw/latexdevcontainer
+RUN apk add curl
+```
+
+To rebuild the image, either:
+
+- With VSCode through the command palette, select `Remote-Containers: Rebuild and reopen in container`
+- With a terminal, go to this directory and `docker-compose build`
+
+### Customize VS code settings
+
+You can customize **settings** and **extensions** in the [devcontainer.json](devcontainer.json) definition file.
+
+### Entrypoint script
+
+You can bind mount a shell script to `/home/vscode/.welcome.sh` to replace the [current welcome script](shell/.welcome.sh).
+
+### Publish a port
+
+To access a port from your host to your development container, publish a port in [docker-compose.yml](docker-compose.yml). You can also now do it directly with VSCode without restarting the container.
+
+### Run other services
+
+1. Modify [docker-compose.yml](docker-compose.yml) to launch other services at the same time as this development container, such as a test database:
+
+    ```yml
+      database:
+        image: postgres
+        restart: always
+        environment:
+          POSTGRES_PASSWORD: password
+    ```
+
+1. In [devcontainer.json](devcontainer.json), change the line `"runServices": ["vscode"],` to `"runServices": ["vscode", "database"],`.
+1. In the VS code command palette, rebuild the container.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,46 @@
+{
+    "name": "texlive",
+    "dockerComposeFile": ["docker-compose.yml"],
+    "service": "vscode",
+    "runServices": ["vscode"],
+    "shutdownAction": "stopCompose",
+    "workspaceFolder": "/workspace",
+    "mounts": [
+        "source=${localWorkspaceFolder}/fonts,target=/usr/share/fonts/my_fonts,type=bind,consistency=cached"
+      ],
+    "postCreateCommand": "fc-cache -fv",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "james-yu.latex-workshop",
+                // Git
+                "eamodio.gitlens",
+                // Other helpers
+                "shardulm94.trailing-spaces",
+                "stkb.rewrap", // rewrap comments after n characters on one line
+                // Other
+                "vscode-icons-team.vscode-icons"
+            ],
+            "settings": {
+                // General settings
+                "files.eol": "\n",
+                // Latex settings
+                "latex-workshop.linting.chktex.enabled": true,
+                "latex-workshop.linting.chktex.exec.path": "chktex",
+                "latex-workshop.latex.clean.subfolder.enabled": true,
+                "latex-workshop.latex.autoClean.run": "onBuilt",
+                "editor.formatOnSave": true,
+                "files.associations": {
+                    "*.tex": "latex"
+                },
+                "latex-workshop.latexindent.path": "latexindent",
+                "latex-workshop.latexindent.args": [
+                    "-c",
+                    "%DIR%/",
+                    "%TMPFILE%",
+                    "-y=defaultIndent: '%INDENT%'"
+                ]
+            }
+        }
+    }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.2"
+
+services:
+  vscode:
+    build: .
+    image: latexdevcontainer
+    volumes:
+      - ../:/workspace
+      # Docker socket to access Docker server
+      - /var/run/docker.sock:/var/run/docker.sock
+      # SSH directory
+      # - ~/.ssh:/root/.ssh
+      # For Windows without WSL, a copy will be made
+      # from /tmp/.ssh to ~/.ssh to fix permissions
+      # - ~/.ssh:/tmp/.ssh:ro
+      # Shell history persistence
+      - ~/.zsh_history:/root/.zsh_history:z
+      # Git config
+      # - ~/.gitconfig:/root/.gitconfig
+    environment:
+      - TZ=
+    entrypoint: ["zsh", "-c", "while sleep 1000; do :; done"]
+ 

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -1,0 +1,66 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {
+		// "editor.insertSpaces": true,
+		// "editor.smoothScrolling": true,
+		// "editor.wordWrap": "on",
+		// "editor.fontLigatures": true,
+		// "editor.renderWhitespace": "boundary",
+		// "editor.formatOnPaste": false,
+        // "editor.formatOnSave": false,
+        // "editor.minimap.enabled": false,
+        "editor.suggestSelection": "recentlyUsedByPrefix",
+        "editor.defaultFormatter": "James-Yu.latex-workshop",
+		"files.trimTrailingWhitespace": true,
+		"latex-workshop.synctex.afterBuild.enabled": true,
+		"latex-workshop.chktex.enabled": true,
+		"latex-workshop.view.pdf.viewer": "tab",
+		"latex-workshop.intellisense.package.enabled": true,
+		"latex-workshop.latex.clean.subfolder.enabled": true,
+		"latex-workshop.latex.autoClean.run":"onFailed",
+		"latex-workshop.latex.autoBuild.run": "onSave",
+		"latex-workshop.latex.external.build.args": [
+			"--shell-escape"
+		],
+		"latex-workshop.texdoc.args": [
+			"--view",
+			"--shell-escape"
+		],
+		"files.exclude": {
+			"**/.project": true,
+			"**/.chktexrc": true,
+			"**/.settings": true,
+			"**/.dockerignore": true,
+			"**/.devcontainer": true,
+			"**/.gitattributes": true,
+			"**/.gitignore": true,
+			"**/makefile": true,
+			"**/fonts": true,
+			"**/*.aux":true,
+			"**/*.out":true,
+			"**/*.fls":true,
+			"**/*.iml":true,
+			"**/*.toc":true,
+			"**/*.gz":true,
+			"**/*.bbl":true,
+			"**/*.lof":true,
+			"**/*.blg":true,
+			"**/*.lot":true,
+			"**/*.fdb_latexmk":true,
+			"**/*.synctex(busy)":true,
+			"**/*.git":true,
+			"**/*.idea":true,
+			"**/*.vscode":true,
+			"**/*.github":true,
+			"**/*.user": true,
+			"**/*.log": true,
+			"**/*.ilk": true,
+			"**/*.bst": true,
+
+		},
+	}
+}


### PR DESCRIPTION
原本使用本模板需要在本机安装Latex的相关组件，这个过程非常的麻烦而且容易出错，借助docker技术使用devcontainer可以极大简化这个过程，能够保证稳定的使用，而且配置了vscode的工作区文件，可以忽略掉一些不需要更改的文件。

目前存在的问题是，docker镜像中没有字体文件，直接执行会报错，解决办法是将需要的字体文件放置在fonts文件夹中，脚本已经配置好了，devcontainer启动的时候就会自动安装映射字体，我不确定这些字体会不会有版权风险所以就没有上传，需要添加一下