### PR TITLE
Update yanputhesis.cls_硕士学科专业名称英文不加粗

### DIFF
--- a/yanputhesis.cls
+++ b/yanputhesis.cls
@@ -646,7 +646,7 @@
         \linespread{1.2} \fEng \sXiaosan \par               % 1.2 倍行距
         \vspace{1\baselineskip}                             % 1 * 22pt * 1.2
         \begin{center}                                      %
-            \fEng \sErhao \textbf{\nwpu@eng@title} \par     %
+            \fEng \sErhao \textbf{Title:\nwpu@eng@title} \par     %
             \fSong \sXiaoer \vspace{3\baselineskip}         %
             \fEng \sXiaosan \textbf{By} \par                %
             \fEng \sXiaosan \textbf{\nwpu@eng@author} \par  %


### PR DESCRIPTION
根据《西北工业大学研究生学位论文写作指南（2025版）》，硕士学科专业名称英文不加粗
<img width="990" height="308" alt="image" src="https://github.com/user-attachments/assets/4df3afed-befe-4a25-b64f-0b7f6133cdf6" />
<img width="1018" height="246" alt="image" src="https://github.com/user-attachments/assets/d4673cf9-a3ef-4854-8a42-3f9186f98995" />
