### PR TITLE
Update yanputhesis.cls_英文标题前加Title: 硕士学科专业名称英文不加粗

### DIFF
--- a/yanputhesis.cls
+++ b/yanputhesis.cls
@@ -646,7 +646,7 @@
         \linespread{1.2} \fEng \sXiaosan \par               % 1.2 倍行距
         \vspace{1\baselineskip}                             % 1 * 22pt * 1.2
         \begin{center}                                      %
-            \fEng \sErhao \textbf{\nwpu@eng@title} \par     %
+            \fEng \sErhao \textbf{Title:\nwpu@eng@title} \par     %
             \fSong \sXiaoer \vspace{3\baselineskip}         %
             \fEng \sXiaosan \textbf{By} \par                %
             \fEng \sXiaosan \textbf{\nwpu@eng@author} \par  %


### PR DESCRIPTION
根据《西北工业大学研究生学位论文写作指南（2025版）》

1. 英文标题前加Title: 
<img width="1119" height="288" alt="image" src="https://github.com/user-attachments/assets/971e10b2-68a2-4630-96b0-d10b436b3a1f" />
2. 硕士学科专业名称英译不加粗:
<img width="997" height="209" alt="image" src="https://github.com/user-attachments/assets/38f8aad0-6e6a-4461-85fb-0cafbe22525e" />
<img width="947" height="211" alt="image" src="https://github.com/user-attachments/assets/3f6031a0-3bfc-4663-bf19-81da9ceed16b" />



