### PR TITLE
Fix formatting for advisor's academic rank

### DIFF
--- a/yanputhesis-sample.tex
+++ b/yanputhesis-sample.tex
@@ -137,7 +137,7 @@
 \school{数学与统计学院}{School of Mathematics and Statistics}% 学院
 \major{数学}{Philosophy in Mathematics}                     % 专业 博士请添加 Ph
 \advisor{\blindreview{李四海}}{\blindreview{Sihai Li}}      % 导师（添加盲评标记）
-\advisorAcademicRank{教授}{Professor}						  % 导师中英学术职位（教授 Professor、副教授 Associate Professor、研究员 Researcher 和讲师 Lecturer）
+\advisorAcademicRank{~教授}{Professor}						  % 导师中英学术职位（教授 Professor、副教授 Associate Professor、研究员 Researcher 和讲师 Lecturer）
 \studentnumber{2016123456}                                  % 学号
 \funding{本研究得到玄学基金（编号23336666）资助。}{         % 基金资助
     The present work is supported by Funding of Metaphysics %


### PR DESCRIPTION
Updated advisor's academic rank formatting.
在最新版格式中，指导教师名字和职称中间有一个空格，如图
<img width="695" height="571" alt="image" src="https://github.com/user-attachments/assets/8334e410-42ca-4bd8-973b-73038d4bec9f" />
